### PR TITLE
feat: Add support for Cloud Compare rotations

### DIFF
--- a/gsconverter/main.py
+++ b/gsconverter/main.py
@@ -38,6 +38,7 @@ def main():
     parser.add_argument("--bbox", nargs=6, type=float, metavar=('minX', 'minY', 'minZ', 'maxX', 'maxY', 'maxZ'), help="Specify the 3D bounding box to crop the point cloud.")
     parser.add_argument("--density_filter", nargs='*', action=DensityFilterAction, help="Filter the points to keep only regions with higher point density. Optionally provide 'voxel_size' and 'threshold_percentage' as two numbers (e.g., --density_filter 0.5 0.25). If no numbers are provided, defaults of 1.0 and 0.32 are used.")
     parser.add_argument("--remove_flyers", nargs='*', action=RemoveFlyersAction, help="Remove flyers based on k-nearest neighbors. Requires two numbers: 'k' (number of neighbors) and 'threshold_factor'.")
+    parser.add_argument("--cc_rotation", type=str, help="Path to the 4x4 transformation matrix from Cloud Compare")
     
     args = parser.parse_args()
     
@@ -111,7 +112,7 @@ def main():
                 data_to_convert = data['vertex'].data
             
             # Call the convert function and pass the data to convert
-            converted_data = convert(data_to_convert, source_format, args.target_format, process_rgb=args.rgb, density_filter=args.density_filter, remove_flyers=args.remove_flyers, bbox=bbox_values, pool=pool)
+            converted_data = convert(data_to_convert, source_format, args.target_format, process_rgb=args.rgb, density_filter=args.density_filter, remove_flyers=args.remove_flyers, bbox=bbox_values, pool=pool, cc_rotation=args.cc_rotation)
             
     except KeyboardInterrupt:
         print("Caught KeyboardInterrupt, terminating workers")

--- a/gsconverter/utils/conversion_functions.py
+++ b/gsconverter/utils/conversion_functions.py
@@ -43,7 +43,7 @@ def convert(data, source_format, target_format, **kwargs):
         return converter.to_cc(process_rgb=process_rgb_flag)
     elif source_format == "cc" and target_format == "3dgs":
         debug_print("[DEBUG] Converting CC to 3DGS...")
-        return converter.to_3dgs()
+        return converter.to_3dgs(cc_rotation=kwargs.get("cc_rotation"))
     elif source_format == "parquet" and target_format == "cc":
         debug_print("[DEBUG] Converting Parquet to CC...")
         return converter.to_cc(process_rgb=process_rgb_flag)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ scikit-learn
 plyfile
 pandas
 pyarrow
+scipy


### PR DESCRIPTION
This commit introduces a new feature to account for Cloud Compare rotations when transforming from the Cloud Compare format to the 3D Gaussian Splatting (3DGS) format.

A new command-line argument `--cc_rotation` has been added, which accepts a path to a 4x4 transformation matrix file. When this argument is provided during a `cc` to `3dgs` conversion, the specified rotation is applied to both the point coordinates and their associated quaternions.

The `scipy` library has been added as a dependency to handle the necessary rotation and quaternion calculations.